### PR TITLE
Fix bug when input is using downcase letter

### DIFF
--- a/src/controller/game_controller.rb
+++ b/src/controller/game_controller.rb
@@ -27,7 +27,7 @@ class GameController
         @is_playing = false
         break
       end
-      select(input[0].ord - 65, input[1].to_i - 1)
+      select(input[0].upcase.ord - 65, input[1].to_i - 1)
     end
   end
 

--- a/test/controller/game_controller_test.rb
+++ b/test/controller/game_controller_test.rb
@@ -47,6 +47,17 @@ class GameControllerTest < Test::Unit::TestCase
     assert_equal('A1', value)
   end
 
+  def test_request_input_downcase
+    input = StringIO.new
+    input.puts 'a1'
+    input.puts 'a2'
+    input.puts 'b1'
+    input.rewind
+    $stdin = input
+    @controller.play
+    assert_false(@controller.is_playing)
+  end
+
   def test_check_cell_b
     @controller.check_cell('B', 0, 1)
     assert_false(@controller.is_playing)


### PR DESCRIPTION
## Description

This pull request aims to fix a bug when the input contains downcase coordinates.

## Requirements

None.

## Additional changes

Added tests to verify it is indeed fixed the bug.
