### PR TITLE
Fix chain method

### DIFF
--- a/src/model/board.rb
+++ b/src/model/board.rb
@@ -47,12 +47,7 @@ class Board < Observable
   end
 
   def make_chain(cord_x, cord_y)
-    # The following checks if the cell value is numeric :)
-    begin
-      check_surroundings(cord_x, cord_y) unless Float(@matrix_board[cord_x][cord_y].value.to_s).nil?
-    rescue StandardError
-      false
-    end
+    check_surroundings(cord_x, cord_y) if @matrix_board[cord_x][cord_y].value.to_s == '0'
     notify_all
   end
 

--- a/test/model/board_test.rb
+++ b/test/model/board_test.rb
@@ -13,4 +13,14 @@ class BoardTest < Test::Unit::TestCase
     board.reveal_cell(0, 0)
     assert_equal(board.matrix_board[0][0].hidden, false)
   end
+
+  def test_no_extra_reveals
+    board = Board.new(2, 1, [
+                        [1, 1],
+                        [1, 'B']
+                      ])
+    board.reveal_cell(0, 1)
+    board.make_chain(0, 1)
+    assert_false(board.completed)
+  end
 end


### PR DESCRIPTION
## Description

This pull request aims to fix the issue related with cell revealing chaining, introduced in my last PR (gracefully overlooked by @humbertoortuzar).

Begin/rescue block hid a critical exception.

Chaining logic was supposed to trigger itself exclusively '0' cells rather than numeric ones.

Closes #33 

## Requirements

None.

## Additional changes

Adds a confirmation test related to this fixed bug.
